### PR TITLE
Fix JSON Schema compatibility by flattening $defs for strict MCP clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 build/
 dist/
+.venv/
 __pycache__/
 src/telemetry/P4MCP.exe
 P4MCP.spec
 .DS_Store
+*.log

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ docutils==0.22.4
 email-validator==2.3.0
 exceptiongroup==1.3.1
 fakeredis==2.33.0
-fastmcp==2.14.2
+fastmcp==2.14.5
 h11==0.16.0
 httpcore==1.0.9
 httpx==0.28.1
@@ -61,7 +61,7 @@ pycparser==2.23
 pydantic==2.12.5
 pydantic-settings==2.12.0
 pydantic_core==2.41.5
-pydocket==0.16.6
+pydocket==0.17.5
 Pygments==2.19.2
 PyJWT==2.10.1
 pyperclip==1.11.0

--- a/src/core/schema_utils.py
+++ b/src/core/schema_utils.py
@@ -1,0 +1,145 @@
+"""
+Schema utilities for MCP client compatibility.
+
+Provides functions to inline $defs/$ref in JSON schemas for strict MCP clients
+that don't support JSON Schema's $defs mechanism (GitHub Copilot, etc.).
+"""
+
+import copy
+from typing import Any, Dict
+
+
+def resolve_ref(ref: str, defs: Dict[str, Any]) -> Dict[str, Any]:
+    """Resolve a $ref pointer to its definition."""
+    # $ref format: "#/$defs/ModelName"
+    if ref.startswith("#/$defs/"):
+        def_name = ref[8:]  # Remove "#/$defs/" prefix
+        if def_name in defs:
+            return copy.deepcopy(defs[def_name])
+    return {"$ref": ref}  # Return as-is if can't resolve
+
+
+def inline_refs(schema: Dict[str, Any], defs: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively inline all $ref references in a schema."""
+    if not isinstance(schema, dict):
+        return schema
+    
+    # If this is a $ref, resolve it
+    if "$ref" in schema and len(schema) == 1:
+        resolved = resolve_ref(schema["$ref"], defs)
+        # Recursively inline any refs in the resolved schema
+        return inline_refs(resolved, defs)
+    
+    # Process all keys recursively
+    result = {}
+    for key, value in schema.items():
+        if key == "$defs":
+            # Skip $defs - we're inlining them
+            continue
+        elif isinstance(value, dict):
+            result[key] = inline_refs(value, defs)
+        elif isinstance(value, list):
+            result[key] = [
+                inline_refs(item, defs) if isinstance(item, dict) else item
+                for item in value
+            ]
+        else:
+            result[key] = value
+    
+    return result
+
+
+def flatten_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Flatten a JSON schema by inlining all $defs references.
+    
+    This transforms schemas like:
+        {
+            "$defs": {"MyModel": {...}},
+            "properties": {"params": {"$ref": "#/$defs/MyModel"}},
+            "required": ["params"]
+        }
+    
+    Into:
+        {
+            "properties": {"params": {...inlined model...}},
+            "required": ["params"]
+        }
+    
+    Args:
+        schema: JSON schema dictionary with potential $defs
+        
+    Returns:
+        Flattened schema with all $refs inlined
+    """
+    if not isinstance(schema, dict):
+        return schema
+    
+    # Extract $defs if present
+    defs = schema.get("$defs", {})
+    
+    # If no $defs, return as-is
+    if not defs:
+        return schema
+    
+    # Inline all references
+    return inline_refs(schema, defs)
+
+
+def unwrap_params_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Unwrap a schema that has a single 'params' property.
+    
+    This transforms schemas like:
+        {
+            "properties": {"params": {actual model schema}},
+            "required": ["params"],
+            "type": "object"
+        }
+    
+    Into just the model schema directly:
+        {actual model schema}
+    
+    This is useful when the tool wrapper adds unnecessary nesting.
+    """
+    if not isinstance(schema, dict):
+        return schema
+    
+    props = schema.get("properties", {})
+    required = schema.get("required", [])
+    
+    # Check if this is a wrapper with just 'params'
+    if (
+        len(props) == 1 
+        and "params" in props 
+        and required == ["params"]
+        and schema.get("type") == "object"
+    ):
+        # Return the inner params schema
+        return props["params"]
+    
+    return schema
+
+
+def process_tool_schema(schema: Dict[str, Any], unwrap_params: bool = True) -> Dict[str, Any]:
+    """
+    Process a tool's input schema for MCP client compatibility.
+    
+    1. Flattens $defs by inlining all $ref references
+    2. Optionally unwraps the 'params' wrapper
+    
+    Args:
+        schema: The tool's inputSchema
+        unwrap_params: If True, unwrap single 'params' wrapper
+        
+    Returns:
+        Processed schema compatible with strict MCP clients
+    """
+    # First flatten any $defs
+    flattened = flatten_schema(schema)
+    
+    # Optionally unwrap the params wrapper
+    if unwrap_params:
+        flattened = unwrap_params_schema(flattened)
+    
+    return flattened

--- a/src/server.py
+++ b/src/server.py
@@ -2,6 +2,7 @@ import json
 import logging
 from fastmcp import FastMCP, Context
 from .core.config import Config
+from .core.schema_utils import flatten_schema
 from .logging.global_logging import setup_logging
 from .logging.session_logging import log_tool_call
 from .core.connection import P4ConnectionManager
@@ -49,9 +50,30 @@ class P4MCPServer:
         try:
             self._initialize_handlers()
             self._register_tools()
+            # Note: Schema flattening is done at request time via tool transformation
+            self._add_schema_transformation()
         except Exception as e:
             logger.error(f"Failed to initialize dependencies: {e}")
             raise
+
+    def _add_schema_transformation(self) -> None:
+        """Add schema transformation to flatten $defs for MCP client compatibility."""
+        from fastmcp.tools.tool import Tool
+        
+        # Store original to_mcp_tool method
+        original_to_mcp_tool = Tool.to_mcp_tool
+        
+        def patched_to_mcp_tool(self, **kwargs):
+            """Patched to_mcp_tool that flattens $defs in input schema."""
+            result = original_to_mcp_tool(self, **kwargs)
+            # Flatten the input schema if it has $defs
+            if hasattr(result, 'inputSchema') and result.inputSchema and "$defs" in result.inputSchema:
+                result.inputSchema = flatten_schema(result.inputSchema)
+            return result
+        
+        # Monkey-patch the method
+        Tool.to_mcp_tool = patched_to_mcp_tool
+        logger.debug("Added schema transformation for MCP client compatibility")
 
     def _initialize_handlers(self) -> None:
         """Initialize handlers with all services"""


### PR DESCRIPTION
Adds runtime schema transformation to inline / references that some MCP clients (GitHub Copilot, Claude, GPT, Gemini) cannot handle.

Fixes #5 and #3