### PR TITLE
fix: run Docker container as non-root user to reduce blast radius

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
+RUN useradd -m mcpuser
 # Set working directory
 WORKDIR /app
 
@@ -17,6 +18,9 @@ COPY src/ ./src/
 
 # Set environment variables
 ENV PYTHONPATH=/app
+ENV P4TICKETS=/home/mcpuser/.p4tickets
 
+RUN mkdir -p /app/logs && chown mcpuser:mcpuser /app/logs
+USER mcpuser
 # Run the server with HTTP transport
 CMD ["python3", "-m", "src.main", "--transport", "stdio"]

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Add the following to your `mcp.json`:
                 "-e", "P4PORT=ssl:perforce.example.com:1666",
                 "-e", "P4USER=your_username",
                 "-e", "P4CLIENT=your_workspace",
-                "-v", "/Users/your_username/.p4tickets:/root/.p4tickets:ro",
+                "-v", "/Users/your_username/.p4tickets:/home/mcpuser/.p4tickets:ro",
                 "p4-mcp-server"
             ]
         }
@@ -156,7 +156,7 @@ Add the following to your `mcp.json`:
 Using P4 tickets:
 ```bash
 # macOS/Linux
--v /Users/your_username/.p4tickets:/root/.p4tickets:ro
+-v /Users/your_username/.p4tickets:/home/mcpuser/.p4tickets:ro
 ```
 
 > **Note:** Use the full path to your tickets file (not `~`). After running `p4 login`, restart the MCP server to pick up the new ticket.
@@ -203,7 +203,7 @@ Example configuration with client root mounted:
                 "-e", "P4PORT=ssl:perforce.example.com:1666",
                 "-e", "P4USER=your_username",
                 "-e", "P4CLIENT=your_workspace",
-                "-v", "/Users/your_username/.p4tickets:/root/.p4tickets",
+                "-v", "/Users/your_username/.p4tickets:/home/mcpuser/.p4tickets",
                 "-v", "/path/to/client/root:/path/to/client/root",
                 "p4-mcp-server"
             ]


### PR DESCRIPTION
- Add non-root mcpuser and switch to it via USER directive
- Set P4TICKETS env var to /home/mcpuser/.p4tickets
- Update README mount paths from /root to /home/mcpuser
- Ensure /app/logs is writable by mcpuser