### PR TITLE
refactor: split CMD into ENTRYPOINT + CMD for flexible arg passing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,6 @@ COPY src/ ./src/
 # Set environment variables
 ENV PYTHONPATH=/app
 
-# Run the server with HTTP transport
-CMD ["python3", "-m", "src.main", "--transport", "stdio"]
+# Run the server
+ENTRYPOINT ["python3", "-m", "src.main"]
+CMD ["--transport", "stdio"]


### PR DESCRIPTION
Replace single CMD with ENTRYPOINT/CMD split so MCP clients can append flags like --readonly, --toolsets, or --transport http without needing --entrypoint override.