### PR TITLE
Add SSL verification options for P4 Code Review API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,8 @@ See the [Windsurf MCP documentation](https://docs.windsurf.com/windsurf/cascade/
 - `P4PORT` - P4 Server address. Examples: `ssl:perforce.example.com:1666`, `localhost:1666`
 - `P4USER` - Your P4 username
 - `P4CLIENT` - Your current P4 workspace. Optional, but recommended
+- `P4MCP_SSL_VERIFY` - Set to `false` to disable SSL verification for P4 Code Review API requests. Default: `true`
+- `P4MCP_CA_BUNDLE` - Path to a custom CA certificate bundle (PEM) for P4 Code Review API requests. Takes priority over `P4MCP_SSL_VERIFY`
 
 ### Supported arguments
 
@@ -414,6 +416,12 @@ See the [Windsurf MCP documentation](https://docs.windsurf.com/windsurf/cascade/
 - `--toolsets` - Specify which tool categories to enable.
   - Available: `files`, `changelists`, `shelves`, `workspaces`, `jobs`, `reviews`
   - Default: All toolsets enabled.
+
+- `--ssl-no-verify` - Disable SSL certificate verification for P4 Code Review API requests.
+  - Useful for environments with self-signed or internal CA certificates.
+
+- `--ca-bundle <path>` - Path to a custom CA certificate bundle (PEM) for P4 Code Review API requests.
+  - Use this to trust an internal CA without disabling verification entirely.
 
 ### Required configurations
 - Use absolute paths for the `command` field in all configurations.
@@ -782,13 +790,24 @@ Example: Even if `noaccessuser` is in `accessgroup` (where MCP is enabled), the 
 </details>
 
 <details>
-  <summary><strong>SSL certificate not trusted</strong></summary>
+  <summary><strong>SSL certificate not trusted (P4 connection)</strong></summary>
 
-**Symptoms**: SSL trust errors when connecting  
+**Symptoms**: SSL trust errors when connecting to the P4 server
 **Solutions**:
 1. Trust the server: `p4 trust -f -y`
 2. Check trust status: `p4 trust -l`
 3. For persistent issues, verify the SSL configuration.
+
+</details>
+
+<details>
+  <summary><strong>SSL certificate errors for P4 Code Review API (reviews)</strong></summary>
+
+**Symptoms**: `CERTIFICATE_VERIFY_FAILED` errors when using review tools
+**Solutions**:
+1. **Custom CA bundle**: Point to your internal CA certificate with `--ca-bundle /path/to/ca.pem` or set the `P4MCP_CA_BUNDLE` environment variable.
+2. **Disable verification**: Use `--ssl-no-verify` or set `P4MCP_SSL_VERIFY=false` (not recommended for production).
+3. **Priority order**: CLI args (`--ca-bundle` / `--ssl-no-verify`) take priority over environment variables, which take priority over the default (verify enabled).
 
 </details>
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -19,21 +19,52 @@ class Config:
 
     # Tool settings
     log_level: str = "INFO"  # DEBUG, INFO, WARNING, ERROR, CRITICAL, OFF, QUIET
-    
+
+    # SSL/TLS settings for Swarm API connections.
+    # True = verify with default CA bundle, False = disable verification,
+    # or a file path to a custom CA certificate bundle (PEM).
+    ssl_verify: Any = True
+
     @classmethod
     def load(cls) -> 'Config':
         """Load configuration from file or environment variables"""
-        
+
         # Default configuration
         config_data = {
             "p4port": os.getenv("P4PORT"),
             "p4user": os.getenv("P4USER"),
             "p4client": os.getenv("P4CLIENT"),
-            "log_level": os.getenv("LOG_LEVEL", "INFO")
+            "log_level": os.getenv("LOG_LEVEL", "INFO"),
+            "ssl_verify": cls._parse_ssl_verify(),
         }
         config_data = {k: v for k, v in config_data.items() if v is not None}
         return cls(**config_data)
-    
+
+    @staticmethod
+    def _parse_ssl_verify():
+        """Parse SSL verification settings from environment variables.
+
+        Supported env vars (checked in order):
+          P4MCP_CA_BUNDLE  – path to a custom CA certificate bundle (PEM file).
+                             When set, requests will verify against this bundle.
+          P4MCP_SSL_VERIFY – "true" (default) to verify with the default CA bundle,
+                             "false" to disable SSL verification entirely.
+        """
+        ca_bundle = os.getenv("P4MCP_CA_BUNDLE")
+        if ca_bundle:
+            if os.path.isfile(ca_bundle):
+                logger.info(f"Using custom CA bundle for Swarm SSL: {ca_bundle}")
+                return ca_bundle
+            else:
+                logger.warning(f"P4MCP_CA_BUNDLE path does not exist: {ca_bundle} — falling back to default")
+
+        ssl_flag = os.getenv("P4MCP_SSL_VERIFY", "true").lower()
+        if ssl_flag == "false":
+            logger.info("Swarm SSL verification disabled via P4MCP_SSL_VERIFY=false")
+            return False
+
+        return True
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert config to dictionary"""
         return {
@@ -41,4 +72,5 @@ class Config:
             "p4user": self.p4user,
             "p4client": self.p4client,
             "log_level": self.log_level,
+            "ssl_verify": self.ssl_verify,
         }

--- a/src/main.py
+++ b/src/main.py
@@ -44,6 +44,18 @@ def parse_args() -> argparse.Namespace:
         help="Allow usage data collection (default: False)"
     )
     parser.add_argument(
+        "--ssl-no-verify",
+        action="store_true",
+        default=False,
+        help="Disable SSL certificate verification for Swarm API requests"
+    )
+    parser.add_argument(
+        "--ca-bundle",
+        type=str,
+        default=None,
+        help="Path to a custom CA certificate bundle (PEM) for Swarm API requests"
+    )
+    parser.add_argument(
         "--transport",
         choices=["stdio", "http"],
         default="stdio",
@@ -82,7 +94,14 @@ def main() -> None:
             if consent_config_exist():
                 logger.info("Telemetry consent config exists.")
                 session_id = start_session()
-        server = P4MCPServer(session_id=session_id, readonly=args.readonly, toolsets=args.toolsets)
+        # Determine SSL verify: --ca-bundle path > --ssl-no-verify > env vars > default (True)
+        if args.ca_bundle:
+            ssl_verify = args.ca_bundle
+        elif args.ssl_no_verify:
+            ssl_verify = False
+        else:
+            ssl_verify = None  # let Config/env decide
+        server = P4MCPServer(session_id=session_id, readonly=args.readonly, toolsets=args.toolsets, ssl_verify=ssl_verify)
         if args.transport == "http":
             logger.info(f"Starting P4 MCP Server with HTTP transport on port {args.port}")
             server.run(transport="http", port=args.port, host="0.0.0.0")

--- a/src/server.py
+++ b/src/server.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class P4MCPServer:
     """Perforce MCP Server with improved structure"""
 
-    def __init__(self, session_id: str = None, readonly: bool = True, toolsets: list = []):
+    def __init__(self, session_id: str = None, readonly: bool = True, toolsets: list = [], ssl_verify=None):
         self.readonly = readonly
         self.toolsets = toolsets
         self.session_id = session_id
@@ -35,6 +35,10 @@ class P4MCPServer:
         setup_logging()
         self.p4config = Config.load()
         self.p4_manager = P4ConnectionManager(self.p4config)
+
+        # CLI args take priority over config/env for SSL verify
+        if ssl_verify is not None:
+            self.p4config.ssl_verify = ssl_verify
 
         if self.readonly:
             logger.info("Running in read-only mode. No write operations will be allowed.")
@@ -64,7 +68,7 @@ class P4MCPServer:
             changelist_services=ChangelistServices(self.p4_manager),
             shelve_services=ShelveServices(self.p4_manager),
             job_services=JobServices(self.p4_manager),
-            review_services=ReviewServices(self.p4_manager)
+            review_services=ReviewServices(self.p4_manager, verify_ssl=self.p4config.ssl_verify)
         )
 
     def process_tool_logs(self, tool_name: str, result: dict, ctx: Context) -> dict:

--- a/src/services/review_services.py
+++ b/src/services/review_services.py
@@ -63,7 +63,15 @@ class ReviewServices:
     Covers all major review endpoints from Swarm API 2025.2
     """
 
-    def __init__(self, connection_manager: P4ConnectionManager, verify_ssl: bool = True):
+    def __init__(self, connection_manager: P4ConnectionManager, verify_ssl=True):
+        """
+        Args:
+            connection_manager: P4 connection manager.
+            verify_ssl: SSL verification for Swarm API requests.
+                True  – verify with default CA bundle (default).
+                False – disable verification entirely.
+                str   – path to a custom CA certificate bundle (PEM).
+        """
         self.connection_manager = connection_manager
         self.verify_ssl = verify_ssl
 


### PR DESCRIPTION
Add --ssl-no-verify and --ca-bundle CLI args, plus P4MCP_SSL_VERIFY and P4MCP_CA_BUNDLE environment variables, to control SSL certificate verification for P4 Code Review API connections.

This enables use in environments with self-signed or internal CA certificates without requiring pip_system_certs (which does not work in PyInstaller-frozen builds).

Priority order: CLI args > env vars > default (verify=True).