### PR TITLE
Feature/review list filters

### DIFF
--- a/src/handlers/review_handlers.py
+++ b/src/handlers/review_handlers.py
@@ -25,6 +25,8 @@ class ReviewsHandlers:
                 after=getattr(params, "after", None),
                 after_updated=getattr(params, "after_updated", None),
                 result_order=getattr(params, "result_order", None),
+                author=getattr(params, "author", None),
+                change=getattr(params, "change", None),
                 projects=getattr(params, "projects", None),
                 state=getattr(params, "state", None),
                 keywords=getattr(params, "keywords", None),

--- a/src/models/review_models.py
+++ b/src/models/review_models.py
@@ -33,16 +33,29 @@ class QueryReviewsParams(PaginatedParams):
 
     action: ReviewAction = Field(
         description=(
-            "Review query action: list all reviews."
-            "'dashboard' for current user (my reviews, needs my attention, authenticated user reviews), "
-            "get specific review, transitions, files_readby, files (from/to), comments"
+            "Review query action: "
+            "'list' to search/filter reviews (supports author, change, project, state, keywords filters), "
+            "'dashboard' for reviews needing the authenticated user's attention (reviews to act on, not all authored reviews), "
+            "'get' for a specific review by ID, "
+            "'transitions', 'files_readby', 'files', 'comments', 'activity' for review details"
         ),
         examples=["list", "dashboard", "get", "transitions", "files_readby", "files", "comments", "activity"],
     )
     review_id: Optional[int] = Field(
         default=None,
-        description="Review ID—required for get, transitions, files_readby, files,  comments, and activity actions",
+        description="Review ID — required for get, transitions, files_readby, files, comments, and activity actions",
         examples=[12345, 67890],
+    )
+    author: Optional[List[str]] = Field(
+        default=None,
+        description="Filter by review author(s) — for list action only",
+        examples=[["alice"], ["alice", "bob"]],
+    )
+    change: Optional[List[int]] = Field(
+        default=None,
+        description="Filter by associated changelist number(s) — for list action only. "
+                    "Use this to find the review for a specific changelist.",
+        examples=[[12345], [12345, 67890]],
     )
     review_fields: Optional[str] = Field(
         default=None,

--- a/src/server.py
+++ b/src/server.py
@@ -317,13 +317,27 @@ class P4MCPServer:
         @self.mcp.tool(tags=["read", "reviews"], enabled="reviews" in self.toolsets)
         async def query_reviews(
             action: Annotated[Literal["list", "dashboard", "get", "transitions", "files_readby", "files", "comments", "activity"], Field(
-                description="Review query action: list all reviews, dashboard for current user, get specific review, transitions, files_readby, files, comments, activity"
+                description="Review query action: "
+                    "'list' to search/filter reviews (supports author, change, project, state, keywords filters), "
+                    "'dashboard' for reviews needing the authenticated user's attention (reviews to act on, not all authored reviews), "
+                    "'get' for a specific review by ID, "
+                    "'transitions', 'files_readby', 'files', 'comments', 'activity' for review details"
             )],
             ctx: Context,
             review_id: Annotated[Optional[int], Field(
                 default=None,
                 description="Review ID - required for get, transitions, files_readby, files, comments, activity actions",
                 examples=[12345, 67890]
+            )] = None,
+            author: Annotated[Optional[List[str]], Field(
+                default=None,
+                description="Filter by review author(s) — for list action only",
+                examples=[["alice"]]
+            )] = None,
+            change: Annotated[Optional[List[int]], Field(
+                default=None,
+                description="Filter by associated changelist number(s) — for list action only. Use this to find the review for a specific changelist.",
+                examples=[[12345]]
             )] = None,
             review_fields: Annotated[Optional[str], Field(
                 default=None,
@@ -362,6 +376,8 @@ class P4MCPServer:
             params = review_m.QueryReviewsParams(
                 action=action,
                 review_id=review_id,
+                author=author,
+                change=change,
                 review_fields=review_fields,
                 comments_fields=comments_fields,
                 up_voters=up_voters,

--- a/src/services/review_services.py
+++ b/src/services/review_services.py
@@ -115,6 +115,8 @@ class ReviewServices:
             after: Optional[str] = None,
             after_updated: Optional[str] = None,
             result_order: Optional[str] = None,
+            author: Optional[List[str]] = None,
+            change: Optional[List[int]] = None,
             projects: Optional[List[str]] = None,
             state: Optional[List[str]] = None,
             keywords: Optional[str] = None,
@@ -137,6 +139,12 @@ class ReviewServices:
                 params["resultOrder"] = result_order
 
             # filters
+            if author:
+                params["author[]"] = author
+            if change:
+                # v11 has no change[] param; use keywords + keywordsFields instead
+                params["keywords"] = " ".join(str(c) for c in change)
+                params["keywordsFields[]"] = ["changes"]
             if projects:
                 params["project[]"] = projects
             if state:


### PR DESCRIPTION
The mcp had trouble finding a review when i asked it to find a review for a  particular change (which wasn't on my dashboard due to being in 'needs review' state) -- it tried to find it on my dashboard instead and got confused. This adds a change filter to the reviews tool which helped it do that better.  Note this is using the v11 api, which is different than v9 not sure if we need to support swarm api v9 or not.