### PR TITLE
Add system truststore support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 src/telemetry/P4MCP.exe
 P4MCP.spec
 .DS_Store
+.venv/

--- a/README.md
+++ b/README.md
@@ -400,6 +400,9 @@ See the [Windsurf MCP documentation](https://docs.windsurf.com/windsurf/cascade/
 - `P4PORT` - P4 Server address. Examples: `ssl:perforce.example.com:1666`, `localhost:1666`
 - `P4USER` - Your P4 username
 - `P4CLIENT` - Your current P4 workspace. Optional, but recommended
+- `P4MCP_TLS_CA_MODE` - TLS certificate source mode.
+  - `system` (default): use OS trust store
+  - `certifi`: disable `truststore` injection and use default Python TLS certificate behavior
 
 ### Supported arguments
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,6 +67,7 @@ shellingham==1.5.4
 sortedcontainers==2.4.0
 sse-starlette==3.2.0
 starlette==0.52.1
+truststore==0.10.4
 typer==0.21.1
 typing-inspection==0.4.2
 typing_extensions==4.15.0

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,11 @@ import logging
 import argparse
 import signal
 from pathlib import Path
+try:
+    import truststore
+    truststore.inject_into_ssl()
+except ImportError:
+    pass  # truststore not installed; falling back to certifi CA bundle
 from src.telemetry.consent import consent_config_exist
 from src.logging.global_logging import setup_logging
 from src.logging.session_logging import start_session, end_session

--- a/src/main.py
+++ b/src/main.py
@@ -2,12 +2,8 @@ import sys
 import logging
 import argparse
 import signal
+import os
 from pathlib import Path
-try:
-    import truststore
-    truststore.inject_into_ssl()
-except ImportError:
-    pass  # truststore not installed; falling back to certifi CA bundle
 from src.telemetry.consent import consent_config_exist
 from src.logging.global_logging import setup_logging
 from src.logging.session_logging import start_session, end_session
@@ -19,6 +15,53 @@ sys.path.insert(0, str(project_root))
 from src.server import P4MCPServer
 
 logger = logging.getLogger(__name__)
+
+
+def configure_tls_ca_mode() -> None:
+    """Configure TLS certificate source based on P4MCP_TLS_CA_MODE.
+
+    Supported values:
+    - system (default): use OS certificate store via truststore
+    - certifi: disable truststore injection and use default Python behavior
+    """
+    raw_mode = os.getenv("P4MCP_TLS_CA_MODE", "system")
+    mode = raw_mode.strip().lower()
+
+    if mode == "":
+        mode = "system"
+        
+    if mode == "system":
+        try:
+            import truststore
+            truststore.inject_into_ssl()
+            logger.info("TLS CA mode: system (using OS trust store via truststore)")
+        except ImportError:
+            logger.warning(
+                "P4MCP_TLS_CA_MODE=system but truststore is not installed; "
+                "continuing with default Python TLS certificate behavior"
+            )
+        return
+
+    if mode == "certifi":
+        logger.info(
+            "TLS CA mode: certifi (truststore injection disabled; "
+            "using default Python TLS certificate behavior)"
+        )
+        return
+
+    logger.warning(
+        "Unrecognized P4MCP_TLS_CA_MODE=%r; defaulting to system",
+        raw_mode,
+    )
+    try:
+        import truststore
+        truststore.inject_into_ssl()
+        logger.info("TLS CA mode: system (using OS trust store via truststore)")
+    except ImportError:
+        logger.warning(
+            "Defaulted to system, but truststore is not installed; "
+            "continuing with default Python TLS certificate behavior"
+        )
 
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
@@ -71,6 +114,7 @@ def signal_handler(signum, frame):
 
 def main() -> None:
     setup_logging("INFO")
+    configure_tls_ca_mode()
 
     
     # Register signal handlers for graceful shutdown


### PR DESCRIPTION
 
This change integrates the truststore library, which instructs Python's ssl module to use the operating system's native certificate store instead of the bundled certifi CA bundle.

P4MCP_TLS_CA_MODE "system" (default) or "certifi" (previous) added.

Should fix #22 